### PR TITLE
Cancel without savepoint was never being called

### DIFF
--- a/flink_scrat/main.py
+++ b/flink_scrat/main.py
@@ -122,7 +122,7 @@ def main():
         conn.submit_job(args.jar_path, args.savepoint_path, args.target_dir, args.job_id, args.anr,
                         args.parallelism, args.entry_class, args.extra_args)
     elif action == "cancel":
-        if args.savepoint is None:
+        if args.savepoint is None or args.savepoint is False:
             conn.cancel_job(args.job_id)
         else:
             conn.cancel_job_with_savepoint(args.job_id, args.target_dir)


### PR DESCRIPTION
args.savepoint is getting set to False by the args parser, so it wasn't None and the script always tried to store a savepoint when cancelling a job.